### PR TITLE
unittests + JWT

### DIFF
--- a/JWT/jwt-signature-apis-challenges/app.js
+++ b/JWT/jwt-signature-apis-challenges/app.js
@@ -25,13 +25,8 @@ app.post('/jwt/none', (req, res) => { //None endpoint
   if (jwt_token == null) {
     res.status(400).send('Send a HTTP request with a body with the format: {jwt: "< Place the JWT to test here >"}');
   } else {
-    const jwt_b64_dec = JWT.decode(jwt_token, { complete: true });
-    if (jwt_b64_dec.header.alg == 'HS256') {
-      secret_key = '885ae2060fbedcfb491c5e8aafc92cab5a8057b3d4c39655acce9d4f09280a20';
-    } else if (jwt_b64_dec.header.alg == 'none') {
-      secret_key = '';
-    }
-    JWT.verify(jwt_token, secret_key, { algorithms: ['none', 'HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
+    secret_key = '885ae2060fbedcfb491c5e8aafc92cab5a8057b3d4c39655acce9d4f09280a20';
+    JWT.verify(jwt_token, secret_key, { algorithms: ['HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
       if (err) {
         res.status(400).json(err);
       } else {

--- a/Python/Flask_Book_Library/Dockerfile
+++ b/Python/Flask_Book_Library/Dockerfile
@@ -15,6 +15,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0
 
+# Uruchomienie testów, w przypadku błędu (zwrócenia statusu różnego od 0), budowanie obrazu zatrzyma się.
+RUN python -m unittest -v project.tests.test_book_model
+
 # Expose the port the app runs on
 EXPOSE 5000
 

--- a/Python/Flask_Book_Library/project/tests/test_book_model.py
+++ b/Python/Flask_Book_Library/project/tests/test_book_model.py
@@ -1,0 +1,73 @@
+from unittest import TestCase
+from project.books.models import Book
+from parameterized import parameterized
+from project import db, app
+
+class TestBookModel(TestCase):
+
+    def setUp (self):
+       with app.app_context():
+            db.create_all()
+
+    def tearDown(self):
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+
+    @parameterized.expand([("1984", "George Orwell", 1948, "dystopia", "available"),
+                           ("Książka", "Autor", 2023, "komedia", "unavailable"),
+                           ("Practical Iot Hacking", "Chatzis Stais", 2021, "dramat", "stolen")])
+    def test_correct_book_data(self, name: str, author: str, year_published: int, book_type: str, status: str):
+        created_book = Book(name, author, year_published, book_type, status)
+        with app.app_context():
+            db.session.add(created_book)
+            db.session.commit()
+
+
+    @parameterized.expand([(1984, "George Orwell", 1948, "dystopia", "available"),
+                           ("Książka", 123, 2023, "komedia", "unavailable"),
+                           ("Practical Iot Hacking", "Chatzis Stais", "2021", "dramat", "stolen"),
+                           ("Pentesting Basics", "Jan kowalski", 1800, 2010, "available"),
+                           ("Dzieci z Bullerbyn", "Szwed szwedowski", 1337,"bajka", 9999)])
+    def test_incorrect_book_data(self, name, author, year_published, book_type, status):
+        created_book = Book(name, author, year_published, book_type, status)
+        with app.app_context():
+            db.session.add(created_book)
+            self.assertRaises(Exception, db.session.commit())
+
+    
+    @parameterized.expand([("1"*1000000, "George Orwell", 1948, "dystopia", "available"),
+                           ("Książka", "1"*1000000, 2023, "komedia", "unavailable"),
+                           ("Practical Iot Hacking", "Chatzis Stais", 2021000000000000000000000, "dramat", "stolen"),
+                           ("Pentesting Basics", "Jan kowalski", 1800, "1"*1000000, "available"),
+                           ("Dzieci z Bullerbyn", "Szwed szwedowski", 1337,"bajka",  "1"*1000000)])
+    def test_extreme_book_data(self, name, author, year_published, book_type, status):
+        created_book = Book(name, author, year_published, book_type, status)
+        with app.app_context():
+            db.session.add(created_book)
+            self.assertRaises(Exception, db.session.commit())
+    
+
+    @parameterized.expand([("1984 union select 1 -- -", "George Orwell", 1948, "dystopia", "available"),
+                           ("Książka", "Autor union select 1 -- -", 2023, "komedia", "unavailable"),
+                           ("Practical Iot Hacking", "Chatzis Stais", "2021 union select 1 -- -", "dramat", "stolen"),
+                           ("Pentesting Basics", "Jan kowalski", 1800, "gatunek union select 1 -- -", "available"),
+                           ("Dzieci z Bullerbyn", "Szwed szwedowski", 1337,"bajka", "unavailable union select 1 -- -")])
+    def test_sql_injection(self, name, author, year_published, book_type, status):
+        created_book = Book(name, author, year_published, book_type, status)
+        with app.app_context():
+            db.session.add(created_book)
+            self.assertRaises(Exception, db.session.commit())
+        
+
+    @parameterized.expand([("<script>alert(1)</script>", "George Orwell", 1948, "dystopia", "available"),
+                           ("Książka", "<script>alert(1)</script>", 2023, "komedia", "unavailable"),
+                           ("Practical Iot Hacking", "Chatzis Stais", "<script>alert(1)</script>", "dramat", "stolen"),
+                           ("Pentesting Basics", "Jan kowalski", 1800, "<script>alert(1)</script>", "available"),
+                           ("Dzieci z Bullerbyn", "Szwed szwedowski", 1337,"bajka", "<script>alert(1)</script>")])
+    def test_xss(self, name, author, year_published, book_type, status):
+        created_book = Book(name, author, year_published, book_type, status)
+        with app.app_context():
+            db.session.add(created_book)
+            self.assertRaises(Exception, db.session.commit())

--- a/Python/Flask_Book_Library/requirements.txt
+++ b/Python/Flask_Book_Library/requirements.txt
@@ -15,3 +15,4 @@ SQLAlchemy==2.0.21
 typing_extensions==4.8.0
 Werkzeug==2.3.7
 WTForms==3.0.1
+parameterized==0.9.0


### PR DESCRIPTION
# Zad 1
Added unit tests:
- correct data.
- incorrect data.
- extreme tests.
- sql injection tests.
- xss tests.

Modified dockerfile to execute tests and stop building if tests fail. Tests needed to have an additional package (_parameterized_) installed.

# Zad 2
Token: _eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhY2NvdW50IjoiYWRtaW5pc3RyYXRvciIsInJvbGUiOiJBZG1pbmlzdHJhdG9yIiwiaWF0IjoxNzAyMjQwOTQ4LCJhdWQiOiJodHRwczovLzEyNy4wLjAuMS9qd3Qvbm9uZSJ9._ could have been used to log in as administrator:


![obraz3](https://github.com/hubertDec/task3/assets/78614745/e8c835d1-7221-43d8-bd15-77fbc44ba8be)

Solution was to remove unneccessary if else statement if algorithm to use is set to _none_. Now the attack method does not work anymore:

![screen3](https://github.com/hubertDec/task3/assets/78614745/70798fde-31c7-4ab3-badb-a4f9117e8c2e)
